### PR TITLE
HOTFIX: サインアップできない問題

### DIFF
--- a/resources/views/auth/signup.blade.php
+++ b/resources/views/auth/signup.blade.php
@@ -49,10 +49,10 @@
 
                 <!-- Confirm Password Input -->
                 <div>
-                    <label for="confirm-password" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+                    <label for="password_confirmation" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
                         パスワード確認
                     </label>
-                    <input type="password" name="confirm-password" id="confirm-password" placeholder="••••••••"
+                    <input type="password" name="password_confirmation" id="password_confirmation" placeholder="••••••••"
                             class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
                             required="">
                     <p id="password-match-error" class="mt-2 text-sm text-red-600 dark:text-red-500 hidden">パスワードが一致しません</p>


### PR DESCRIPTION
name="password_confirmation"がconfirm-passwordとなっていたので戻した