### PR TITLE
Fix/todo解消

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -41,7 +41,7 @@ class AuthController extends Controller
 
         if (Auth::attempt($credentials)) {
             $request->session()->regenerate();
-            return redirect()->intended('/dashboard');
+            return redirect()->intended('/posts');
         }
 
         return back()->withErrors(['email' => 'メールアドレスまたはパスワードが正しくありません。']);

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -74,7 +74,7 @@ class AuthController extends Controller
             ]
         );
 
-        User::create(
+        $user = User::create(
             [
                 'name' => $request->name,
                 'email' => $request->email,
@@ -82,7 +82,10 @@ class AuthController extends Controller
             ]
         );
 
-        return redirect('/login')->with('success', '登録が完了しました。ログインしてください。');
+        Auth::login($user);
+        $request->session()->regenerate();
+
+        return redirect('/posts');
     }
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -15,6 +15,14 @@ class Post extends Model
     ];
 
     /**
+     * 紐づくユーザー
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
      * 紐づく音源
      */
     public function music()


### PR DESCRIPTION
PR粒度細かすぎたらごめんなさい
slack TODOより

* ログイン直後‘/dashboard’(404)に飛ばされるされる  ---> /pagesへ
* サインアップ直後‘/login’へ飛ばすのではなくログイン済みとしてプロフィールページかタイムラインへ直行 ---> ログイン済みで/pagesへ

